### PR TITLE
Add change_detection to only detect changes when True

### DIFF
--- a/crawl/artifactprocessor.py
+++ b/crawl/artifactprocessor.py
@@ -25,13 +25,17 @@ def augment_artifact_def(repo_root_path, art_def, source_exclusions):
         # never released?
         art_def.requires_release = True
         art_def.release_reason = releasereason.ReleaseReason.FIRST
-    else:    
-        has_changed = _has_changed_since_last_release(repo_root_path, art_def, source_exclusions)
-        if has_changed:
-            art_def.requires_release = True
-            art_def.release_reason = releasereason.ReleaseReason.ARTIFACT
+    else:
+        if art_def.change_detection:
+            has_changed = _has_changed_since_last_release(repo_root_path, art_def, source_exclusions)
+            if has_changed:
+                art_def.requires_release = True
+                art_def.release_reason = releasereason.ReleaseReason.ARTIFACT
+            else:
+                art_def.requires_release = False
         else:
-            art_def.requires_release = False
+            art_def.requires_release = True
+            art_def.release_reason = releasereason.ReleaseReason.ALWAYS
     return art_def
 
 def _get_library_path(repo_root_path, art_def):

--- a/crawl/crawler.py
+++ b/crawl/crawler.py
@@ -330,7 +330,7 @@ class Crawler:
                     elif transitive_dep_requires_release:
                         artifact_def.release_reason = ReleaseReason.TRANSITIVE
                     else:
-                        artifact_def.release_reason = ReleaseReason.FORCE
+                        artifact_def.release_reason = ReleaseReason.ALWAYS
                     updated_artifact_defs.append(artifact_def)
 
         # process all artifact nodes belonging to the current library, 

--- a/crawl/libaggregator.py
+++ b/crawl/libaggregator.py
@@ -90,6 +90,8 @@ class LibraryNode:
             return "+"
         elif release_reason == ReleaseReason.FIRST:
             return "++"
+        elif release_reason == ReleaseReason.ALWAYS:
+            return "!"
         else:
             raise Exception("Unhandled release reason: %s" % self.release_reason)
     
@@ -131,23 +133,23 @@ def _get_lib_release_reason(current_release_reason, proposed_release_reason):
     Since we are concerned with libraries here, not artifacts, this method
     defines the precedence for release reasons.
     """
-    if current_release_reason == ReleaseReason.FORCE:
+    if current_release_reason == ReleaseReason.ALWAYS:
         pass
     if current_release_reason == ReleaseReason.FIRST:
-        if proposed_release_reason in (ReleaseReason.FORCE,):
+        if proposed_release_reason in (ReleaseReason.ALWAYS,):
             return proposed_release_reason
     if current_release_reason == ReleaseReason.ARTIFACT:
         if proposed_release_reason in (ReleaseReason.FIRST,
-                                       ReleaseReason.FORCE,):
+                                       ReleaseReason.ALWAYS,):
             return proposed_release_reason
     if current_release_reason == ReleaseReason.POM:
         if proposed_release_reason in (ReleaseReason.FIRST,
-                                       ReleaseReason.FORCE,
+                                       ReleaseReason.ALWAYS,
                                        ReleaseReason.ARTIFACT,):
             return proposed_release_reason
     if current_release_reason == ReleaseReason.TRANSITIVE:
         if proposed_release_reason in (ReleaseReason.FIRST,
-                                       ReleaseReason.FORCE,
+                                       ReleaseReason.ALWAYS,
                                        ReleaseReason.ARTIFACT,
                                        ReleaseReason.POM,):
             return proposed_release_reason

--- a/crawl/releasereason.py
+++ b/crawl/releasereason.py
@@ -8,7 +8,7 @@ For full license text, see the LICENSE file in the repo root or https://opensour
 class ReleaseReason(object):
     FIRST = "artifact has never been released"
     ARTIFACT = "binary artifact changed"
-    ALWAYS = "always released (--force option used or change detection disabled)"
+    ALWAYS = "always released"
     TRANSITIVE = "transitive dependency changed"
     POM = "pom changed"
 

--- a/crawl/releasereason.py
+++ b/crawl/releasereason.py
@@ -8,7 +8,7 @@ For full license text, see the LICENSE file in the repo root or https://opensour
 class ReleaseReason(object):
     FIRST = "artifact has never been released"
     ARTIFACT = "binary artifact changed"
+    ALWAYS = "always released (--force option used or change detection disabled)"
     TRANSITIVE = "transitive dependency changed"
     POM = "pom changed"
-    FORCE = "forced release"
 

--- a/query_maven_metadata.py
+++ b/query_maven_metadata.py
@@ -62,7 +62,7 @@ def _parse_arguments(args):
     parser.add_argument("--filter", type=str, required=False,
         help="Generic query filter, currently only supported for artifact queries")
     parser.add_argument("--force", required=False, action='store_true',
-        help="If set, always generated poms, regardless of whether an artifact has changed since it was last released")
+        help="Simulates release information when --force option is used")
 
     return parser.parse_args(args)
 

--- a/query_maven_metadata.py
+++ b/query_maven_metadata.py
@@ -61,6 +61,8 @@ def _parse_arguments(args):
     # this is experimental and not generalized yet
     parser.add_argument("--filter", type=str, required=False,
         help="Generic query filter, currently only supported for artifact queries")
+    parser.add_argument("--force", required=False, action='store_true',
+        help="If set, always generated poms, regardless of whether an artifact has changed since it was last released")
 
     return parser.parse_args(args)
 
@@ -155,7 +157,7 @@ if __name__ == "__main__":
 
     if crawl_artifact_dependencies:
         crawler = crawler.Crawler(ws, cfg.pom_template, args.verbose)
-        artifact_result = crawler.crawl(packages)
+        artifact_result = crawler.crawl(packages, force=args.force)
         library_nodes = libaggregator.get_libraries_to_release(artifact_result.nodes)
 
         if args.library_release_plan_tree:

--- a/tests/artifactprocessortest.py
+++ b/tests/artifactprocessortest.py
@@ -70,6 +70,17 @@ class ArtifactProcessorTest(unittest.TestCase):
         self.assertFalse(art_def.requires_release)
         self.assertEqual(None, art_def.release_reason)
 
+    def test_artifact_without_changes_always_release(self):
+        repo_root_path = self._setup_repo_with_package("pack1/pack2")
+        current_artifact_hash = git.get_dir_hash(repo_root_path, "pack1/pack2", exclusions.src_exclusions())
+        art_def = buildpom.MavenArtifactDef("g1", "a1", "1.1.0", bazel_package="pack1/pack2", released_version="1.2.0", released_artifact_hash=current_artifact_hash, change_detection=False)
+
+        art_def = artifactprocessor.augment_artifact_def(repo_root_path, art_def, exclusions.src_exclusions())
+
+        self.assertNotEqual(None, art_def.requires_release)
+        self.assertTrue(art_def.requires_release, "Expected artifact to require release")
+        self.assertEqual(releasereason.ReleaseReason.ALWAYS, art_def.release_reason)
+
     def test_artifact_with_changes_since_last_release__new_file(self):
         package = "pack1/pack2"
         repo_root_path = self._setup_repo_with_package(package)

--- a/tests/crawlertest.py
+++ b/tests/crawlertest.py
@@ -139,7 +139,7 @@ class CrawlerTest(unittest.TestCase):
 
         self.assertEqual(6, len(result.pomgens))
         for p in result.pomgens:
-            self.assertEqual(rr.ReleaseReason.FORCE,
+            self.assertEqual(rr.ReleaseReason.ALWAYS,
                 p.artifact_def.release_reason)
 
     def test_all_libs_changed(self):

--- a/tests/libaggregatortest.py
+++ b/tests/libaggregatortest.py
@@ -111,35 +111,35 @@ class LibAggregatorTest(unittest.TestCase):
         self.assertEqual(ReleaseReason.FIRST, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FIRST, ReleaseReason.FIRST))
         self.assertEqual(ReleaseReason.FIRST, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FIRST, ReleaseReason.TRANSITIVE))
         self.assertEqual(ReleaseReason.FIRST, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FIRST, ReleaseReason.POM))
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FIRST, ReleaseReason.FORCE))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FIRST, ReleaseReason.ALWAYS))
 
     def test_release_reason_precedence__artifact(self):
         self.assertEqual(ReleaseReason.ARTIFACT, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ARTIFACT, ReleaseReason.ARTIFACT))
         self.assertEqual(ReleaseReason.FIRST, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ARTIFACT, ReleaseReason.FIRST))
         self.assertEqual(ReleaseReason.ARTIFACT, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ARTIFACT, ReleaseReason.TRANSITIVE))
         self.assertEqual(ReleaseReason.ARTIFACT, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ARTIFACT, ReleaseReason.POM))
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ARTIFACT, ReleaseReason.FORCE))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ARTIFACT, ReleaseReason.ALWAYS))
 
     def test_release_reason_precedence__transitive(self):
         self.assertEqual(ReleaseReason.ARTIFACT, crawl.libaggregator._get_lib_release_reason(ReleaseReason.TRANSITIVE, ReleaseReason.ARTIFACT))
         self.assertEqual(ReleaseReason.FIRST, crawl.libaggregator._get_lib_release_reason(ReleaseReason.TRANSITIVE, ReleaseReason.FIRST))
         self.assertEqual(ReleaseReason.TRANSITIVE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.TRANSITIVE, ReleaseReason.TRANSITIVE))
         self.assertEqual(ReleaseReason.POM, crawl.libaggregator._get_lib_release_reason(ReleaseReason.TRANSITIVE, ReleaseReason.POM))
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.TRANSITIVE, ReleaseReason.FORCE))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.TRANSITIVE, ReleaseReason.ALWAYS))
 
     def test_release_reason_precedence__pom(self):
         self.assertEqual(ReleaseReason.ARTIFACT, crawl.libaggregator._get_lib_release_reason(ReleaseReason.POM, ReleaseReason.ARTIFACT))
         self.assertEqual(ReleaseReason.FIRST, crawl.libaggregator._get_lib_release_reason(ReleaseReason.POM, ReleaseReason.FIRST))
         self.assertEqual(ReleaseReason.POM, crawl.libaggregator._get_lib_release_reason(ReleaseReason.POM, ReleaseReason.TRANSITIVE))
         self.assertEqual(ReleaseReason.POM, crawl.libaggregator._get_lib_release_reason(ReleaseReason.POM, ReleaseReason.POM))
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.POM, ReleaseReason.FORCE))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.POM, ReleaseReason.ALWAYS))
         
     def test_release_reason_precedence__force(self):
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FORCE, ReleaseReason.ARTIFACT))
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FORCE, ReleaseReason.FIRST))
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FORCE, ReleaseReason.TRANSITIVE))
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FORCE, ReleaseReason.POM))
-        self.assertEqual(ReleaseReason.FORCE, crawl.libaggregator._get_lib_release_reason(ReleaseReason.FORCE, ReleaseReason.FORCE))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ALWAYS, ReleaseReason.ARTIFACT))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ALWAYS, ReleaseReason.FIRST))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ALWAYS, ReleaseReason.TRANSITIVE))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ALWAYS, ReleaseReason.POM))
+        self.assertEqual(ReleaseReason.ALWAYS, crawl.libaggregator._get_lib_release_reason(ReleaseReason.ALWAYS, ReleaseReason.ALWAYS))
 
     def _create_library_artifact_node(self, group_id, artifact_id, version,
                                       library_path, requires_release,


### PR DESCRIPTION
Add an optional flag change_detection. If it is not set, pomgen detects changes and will only generate pom if changes detected. If change_detection is explicitly set to False, pomgen would always generate pom no matter if there is change to release.
pomgen query result would be marked ` ! always released (change detection is disabled)`.