### PR TITLE
"always" release reason takes precedence

### DIFF
--- a/pomgen.py
+++ b/pomgen.py
@@ -67,7 +67,7 @@ def main(args):
     spider = crawler.Crawler(ws, cfg.pom_template, args.verbose)
     result = spider.crawl(packages,
                           follow_monorepo_references=args.recursive,
-                          force=args.force)
+                          force_release=args.force)
 
     if len(result.pomgens) == 0:
         logger.info("No releases are required. pomgen will not generate any pom files. To force pom generation, use pomgen's --force option.")

--- a/query_maven_metadata.py
+++ b/query_maven_metadata.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
 
     if crawl_artifact_dependencies:
         crawler = crawler.Crawler(ws, cfg.pom_template, args.verbose)
-        artifact_result = crawler.crawl(packages, force=args.force)
+        artifact_result = crawler.crawl(packages, force_release=args.force)
         library_nodes = libaggregator.get_libraries_to_release(artifact_result.nodes)
 
         if args.library_release_plan_tree:


### PR DESCRIPTION
@dylanShark quick review please.  Now, with --force, the release reason is always "always", taking precedence over any other release reason.  I think that makes more sense.