### PR TITLE
This test doens't run bazel, it doesn't need .bazelversion (#58)

### DIFF
--- a/tests/crawlertest.py
+++ b/tests/crawlertest.py
@@ -53,8 +53,6 @@ class CrawlerTest(unittest.TestCase):
         self._write_all_build_pom_released(self.repo_root_path)
         self.cwd = os.getcwd()
         os.chdir(self.repo_root_path)
-        with open('.bazelversion', 'w') as output:
-            output.write('0.0.0')
         ws = workspace.Workspace(self.repo_root_path, "",
                                  [], exclusions.src_exclusions())
         self.crawler = crawler.Crawler(ws, pom_template="")


### PR DESCRIPTION
(cherry picked from commit a6dd9562ae63408335949d990701e54dbe35dd7b)