### PR TITLE
Some pom templates still have associated bazel artifacts

### DIFF
--- a/common/pomgenmode.py
+++ b/common/pomgenmode.py
@@ -4,6 +4,7 @@ All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause
 For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 """
+import types
 
 def from_string(pomgenmode_string):
     """
@@ -23,7 +24,7 @@ class PomGenMode:
     The pom generation mode, as specified by the `pom_generation_mode` attribute
     of the `maven_artifact` rule.
     """
-    def __init__(self, name, produces_artifact, bazel_produced_artifact):
+    def __init__(self, name, produces_artifact):
         """
         name:
           The name of this pom_generation_mode
@@ -35,7 +36,14 @@ class PomGenMode:
         """
         self.name = name
         self.produces_artifact = produces_artifact
-        self.bazel_produced_artifact = bazel_produced_artifact
+
+        def bazel_produced_artifact(self, pom_template_content):
+            """
+            Whether this pomgen mode represents an artifact that is built by
+            Bazel (ie a jar)
+            Default is True.
+            """
+            raise Exception("Method must be implemented")
 
     def __str__(self):
         return self.name
@@ -47,20 +55,24 @@ class PomGenMode:
 # "interesting" pom content is only the <dependencies> section, which is based
 # on BUILD file content
 DYNAMIC = PomGenMode("dynamic",
-                     produces_artifact=True,
-                     bazel_produced_artifact=True,)
+                     produces_artifact=True,)
+DYNAMIC.bazel_produced_artifact = types.MethodType(lambda self, pom_template_content: True, DYNAMIC)
 
 # the pom is generated based on a custom template file only
 TEMPLATE = PomGenMode("template",
-                      produces_artifact=True,
-                      bazel_produced_artifact=False,)
+                      produces_artifact=True,)
+# this is an edge case - for custom pom templates, the packaging tends to be
+# "pom" - that's the whole point. but we have a couple of cases with different
+# values (such as maven-plugin), in which case bazel is expected to build
+# something also
+TEMPLATE.bazel_produced_artifact = types.MethodType(lambda self, pom_template_content: pom_template_content.find("<packaging>pom</packaging>") == -1, TEMPLATE)
 
 # this bazel package is skipped over at pom generation time
 # dependencies from this bazel package are "pushed up" to the closest parent
 # that has an artifact producing pom_generation_mode
 SKIP = PomGenMode("skip",
-                  produces_artifact=False,
-                  bazel_produced_artifact=False,)
+                  produces_artifact=False,)
+SKIP.bazel_produced_artifact = types.MethodType(lambda self, pom_template_content: False, SKIP)
 
 
 DEFAULT = DYNAMIC

--- a/crawl/dependency.py
+++ b/crawl/dependency.py
@@ -204,7 +204,8 @@ class MonorepoDependency(AbstractDependency):
 
     @property
     def bazel_buildable(self):
-        return self._artifact_def.pom_generation_mode.bazel_produced_artifact
+        pom_template = self._artifact_def.custom_pom_template_content
+        return self._artifact_def.pom_generation_mode.bazel_produced_artifact(pom_template)
 
     @property
     def references_artifact(self):

--- a/crawl/pom.py
+++ b/crawl/pom.py
@@ -8,7 +8,6 @@ This module contains pom.xml generation logic.
 """
 
 from common import pomgenmode
-from common import mdfiles
 import copy
 from crawl import bazel
 from crawl import pomparser
@@ -62,10 +61,7 @@ def get_pom_generator(workspace, pom_template, artifact_def, dependency):
             return DynamicPomGen(
                 workspace, artifact_def, dependency, pom_template)
     elif mode is pomgenmode.TEMPLATE:
-        content, _ = mdfiles.read_file(workspace.repo_root_path,
-                                       artifact_def.bazel_package,
-                                       artifact_def.pom_template_file)
-        return TemplatePomGen(workspace, artifact_def, dependency, content)
+        return TemplatePomGen(workspace, artifact_def, dependency)
     elif mode is pomgenmode.SKIP:
         return NoopPomGen(workspace, artifact_def, dependency)
     else:
@@ -281,9 +277,8 @@ class TemplatePomGen(AbstractPomGen):
     """
     Generates a pom.xml based on a template file.
     """
-    def __init__(self, workspace, artifact_def, dependency, template_content):
+    def __init__(self, workspace, artifact_def, dependency):
         super(TemplatePomGen, self).__init__(workspace, artifact_def, dependency)
-        self.template_content = template_content
         self.crawled_bazel_packages = set()
         self.crawled_external_dependencies = set()
 
@@ -295,7 +290,7 @@ class TemplatePomGen(AbstractPomGen):
         self.crawled_external_dependencies = crawled_external_dependencies
 
     def gen(self, pomcontenttype):
-        pom_content, parsed_dependencies = self._process_pom_template_content(self.template_content)
+        pom_content, parsed_dependencies = self._process_pom_template_content(self.artifact_def.custom_pom_template_content)
 
         properties = self._get_properties(pomcontenttype, parsed_dependencies)
 

--- a/tests/buildpomtest.py
+++ b/tests/buildpomtest.py
@@ -30,7 +30,7 @@ class BuildPomTest(unittest.TestCase):
         self.assertEqual(version, art_def.version)
         self.assertEqual([], art_def.deps)
         self.assertIs(pomgenmode.DYNAMIC, art_def.pom_generation_mode)
-        self.assertEqual(None, art_def.pom_template_file)
+        self.assertEqual(None, art_def.custom_pom_template_content)
         self.assertTrue(art_def.include_deps)
         self.assertTrue(art_def.change_detection)
         self.assertEqual(package_rel_path, art_def.bazel_package)
@@ -74,7 +74,7 @@ class BuildPomTest(unittest.TestCase):
         self.assertEqual(version, art_def.version)
         self.assertEqual([], art_def.deps)
         self.assertIs(pomgenmode.DYNAMIC, art_def.pom_generation_mode)
-        self.assertEqual(None, art_def.pom_template_file)
+        self.assertEqual(None, art_def.custom_pom_template_content)
         self.assertTrue(art_def.include_deps)
         self.assertTrue(art_def.change_detection)
         self.assertEqual(package_rel_path, art_def.bazel_package)
@@ -108,6 +108,7 @@ class BuildPomTest(unittest.TestCase):
         art_def = buildpom.parse_maven_artifact_def(repo_root, package_rel_path)
 
         self.assertIs(pomgenmode.DYNAMIC, art_def.pom_generation_mode)
+        self.assertTrue(art_def.pom_generation_mode.produces_artifact)
 
     def test_parse_BUILD_pom__template_pomgen_mode(self):
         package_rel_path = "package1/package2"
@@ -122,6 +123,7 @@ class BuildPomTest(unittest.TestCase):
         art_def = buildpom.parse_maven_artifact_def(repo_root, package_rel_path)
 
         self.assertIs(pomgenmode.TEMPLATE, art_def.pom_generation_mode)
+        self.assertTrue(art_def.pom_generation_mode.produces_artifact)
 
     def test_parse_BUILD_pom__skip_pomgen_mode(self):
         package_rel_path = "package1/package2"
@@ -140,13 +142,14 @@ class BuildPomTest(unittest.TestCase):
         self.assertEqual(None, art_def.artifact_id)
         self.assertEqual(None, art_def.version)
         self.assertEqual([], art_def.deps)
-        self.assertEqual(None, art_def.pom_template_file)
+        self.assertEqual(None, art_def.custom_pom_template_content)
         self.assertTrue(art_def.include_deps)
         self.assertTrue(art_def.change_detection)
         self.assertEqual(package_rel_path, art_def.bazel_package)
         self.assertEqual(None, art_def.released_version)
         self.assertEqual(None, art_def.released_artifact_hash)
         self.assertEqual(None, art_def.version_increment_strategy)
+        self.assertFalse(art_def.pom_generation_mode.produces_artifact)
 
     def test_load_pom_xml_released(self):
         package_rel_path = "package1/package2"

--- a/tests/dependencytest.py
+++ b/tests/dependencytest.py
@@ -418,6 +418,47 @@ class DependencyTest(unittest.TestCase):
         self.assertEqual("classifier", dep_copy.classifier)
         self.assertEqual("scope", dep_copy.scope)
 
+    def test_bazel_buildable__external_dep(self):
+        artifact = "com.google.guava:guava:20.0"
+
+        dep = dependency.new_dep_from_maven_art_str(artifact, "name")
+
+        self.assertFalse(dep.bazel_buildable)
+
+    def test_bazel_buildable__source_dep__skip_pom_gen(self):
+        art_def = buildpom.maven_artifact("g1", "a1", "1.0")
+        art_def = buildpom._augment_art_def_values(art_def, None, "pack1", None, None, pomgenmode.SKIP)
+
+        dep = dependency.new_dep_from_maven_artifact_def(art_def, None)
+
+        self.assertFalse(dep.bazel_buildable)
+
+    def test_bazel_buildable__source_dep__dynamic_pom_gen(self):
+        art_def = buildpom.maven_artifact("g1", "a1", "1.0")
+        art_def = buildpom._augment_art_def_values(art_def, None, "pack1", None, None, pomgenmode.DYNAMIC)
+
+        dep = dependency.new_dep_from_maven_artifact_def(art_def, None)
+
+        self.assertTrue(dep.bazel_buildable)
+
+    def test_bazel_buildable__source_dep__template_pom_gen__pom_packaging(self):
+        art_def = buildpom.maven_artifact("g1", "a1", "1.0")
+        art_def = buildpom._augment_art_def_values(art_def, None, "pack1", None, None, pomgenmode.TEMPLATE)
+        art_def.custom_pom_template_content = "<packaging>pom</packaging>"
+
+        dep = dependency.new_dep_from_maven_artifact_def(art_def, None)
+
+        self.assertFalse(dep.bazel_buildable)
+
+    def test_bazel_buildable__source_dep__template_pom_gen__other_packaging(self):
+        art_def = buildpom.maven_artifact("g1", "a1", "1.0")
+        art_def = buildpom._augment_art_def_values(art_def, None, "pack1", None, None, pomgenmode.TEMPLATE)
+        art_def.custom_pom_template_content = "<packaging>maven-plugin</packaging>"
+
+        dep = dependency.new_dep_from_maven_artifact_def(art_def, None)
+
+        self.assertTrue(dep.bazel_buildable)
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/pomtest.py
+++ b/tests/pomtest.py
@@ -152,10 +152,12 @@ class PomTest(unittest.TestCase):
             )""", [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep,template_content = """
-            logback_old_syntax #{ch_qos_logback_logback_classic.version}
-            logback_new_syntax #{ch.qos.logback:logback-classic:version}
-            monorepo artifact version #{version}""")
+        artifact_def.custom_pom_template_content = """
+logback_old_syntax #{ch_qos_logback_logback_classic.version}
+logback_new_syntax #{ch.qos.logback:logback-classic:version}
+monorepo artifact version #{version}
+"""
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
 
         generated_pom = pomgen.gen(pom.PomContentType.RELEASE)
 
@@ -172,8 +174,8 @@ class PomTest(unittest.TestCase):
         srpc_artifact_def = buildpom.MavenArtifactDef("com.grail.srpc",
                                                       "srpc-api", "5.6.7")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep,template_content = """
-            srpc #{com.grail.srpc:srpc-api:version}""")
+        artifact_def.custom_pom_template_content = "srpc #{com.grail.srpc:srpc-api:version}"
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
         pomgen.register_all_dependencies(set([dependency.MonorepoDependency(srpc_artifact_def, bazel_target=None)]), set(), ())
 
         generated_pom = pomgen.gen(pom.PomContentType.RELEASE)
@@ -191,9 +193,9 @@ class PomTest(unittest.TestCase):
                 artifact = "g:a:20",
             )""", [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
+        artifact_def.custom_pom_template_content = "srpc #{g:a:version}"
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep,template_content = """
-            srpc #{g:a:version}""")
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
         art = buildpom.MavenArtifactDef("g","a","1", bazel_package="a/b/c")
         d = dependency.MonorepoDependency(art, bazel_target=None)
         pomgen.register_all_dependencies(set([d]), set(), ())
@@ -223,9 +225,9 @@ class PomTest(unittest.TestCase):
 
         """, [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
+        artifact_def.custom_pom_template_content = "srpc #{g:a:version}"
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep,template_content = """
-            srpc #{g:a:version}""")
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
 
         pomgen.gen(pom.PomContentType.RELEASE)
 
@@ -248,9 +250,9 @@ class PomTest(unittest.TestCase):
 
         """, [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
+        artifact_def.custom_pom_template_content = "srpc #{g:a:version}"
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep,template_content = """
-            srpc #{g:a:version}""")
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
 
         with self.assertRaises(Exception) as ctx:
             pomgen.gen(pom.PomContentType.RELEASE)
@@ -272,10 +274,12 @@ class PomTest(unittest.TestCase):
                                                     "srpc-api", "5.6.7")
         srpc_artifact_def = buildpom._augment_art_def_values(srpc_artifact_def, None, "pack1", None, None, pomgenmode.DYNAMIC)
         dep = dependency.new_dep_from_maven_artifact_def(srpc_artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep,template_content = """
-            this artifact version #{version}
-            logback #{ch.qos.logback:logback-classic:version}
-            srpc #{com.grail.srpc:srpc-api:version}""")
+        artifact_def.custom_pom_template_content = """
+this artifact version #{version}
+logback #{ch.qos.logback:logback-classic:version}
+srpc #{com.grail.srpc:srpc-api:version}
+"""
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
         pomgen.register_all_dependencies(set([dependency.MonorepoDependency(srpc_artifact_def, bazel_target=None)]), set(), ())
 
         generated_pom = pomgen.gen(pomcontenttype=pom.PomContentType.GOLDFILE)
@@ -311,7 +315,8 @@ __pomgen.end_dependency_customization__
         ws = workspace.Workspace("some/path", "", [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep, pom_template)
+        artifact_def.custom_pom_template_content = pom_template
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
 
         generated_pom = pomgen.gen(pom.PomContentType.RELEASE)
 
@@ -367,7 +372,8 @@ __pomgen.end_dependency_customization__
         ws = workspace.Workspace("some/path", "", [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep, pom_template)
+        artifact_def.custom_pom_template_content = pom_template
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
 
         generated_pom = pomgen.gen(pom.PomContentType.RELEASE)
 
@@ -404,7 +410,8 @@ __pomgen.end_dependency_customization__
         ws = workspace.Workspace("some/path", "", [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep, pom_template)
+        artifact_def.custom_pom_template_content = pom_template
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
         crawled_package = dependency.ThirdPartyDependency("name", "c.s.sconems", "abstractions", "0.0.1")
         pomgen.register_all_dependencies(set([crawled_package]), set(), ())
 
@@ -443,7 +450,8 @@ __pomgen.end_dependency_customization__
         ws = workspace.Workspace("some/path", "", [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep, pom_template)
+        artifact_def.custom_pom_template_content = pom_template
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
         crawled_dep = dependency.ThirdPartyDependency("name", "cg", "ca", "0.0.1")
         pomgen.register_all_dependencies(set(), set([crawled_dep]), ())
 
@@ -511,7 +519,8 @@ __pomgen.end_dependency_customization__
         ws = workspace.Workspace("some/path", "", [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep, pom_template)
+        artifact_def.custom_pom_template_content = pom_template
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
         crawled_dep = dependency.ThirdPartyDependency("name", "cg", "ca", "0.0.1")
         pomgen.register_all_dependencies(set(), set([crawled_dep]), ())
 
@@ -561,7 +570,8 @@ __pomgen.end_dependency_customization__
         ws = workspace.Workspace("some/path", "", [], exclusions.src_exclusions())
         artifact_def = buildpom.maven_artifact("groupId", "artifactId", "1.2.3")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep, pom_template)
+        artifact_def.custom_pom_template_content = pom_template
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
         crawled_dep = dependency.ThirdPartyDependency("name", "cg", "ca", "0.0.1")
         pomgen.register_all_dependencies(set(), set([crawled_dep]), ())
 
@@ -578,8 +588,8 @@ __pomgen.end_dependency_customization__
         artifact_def = buildpom.maven_artifact("groupId", "artifactId",
                                                "1.2.3")
         dep = dependency.new_dep_from_maven_artifact_def(artifact_def)
-        pomgen = pom.TemplatePomGen(ws, artifact_def, dep,template_content = """
-            my pom template with a bad ref #{bad1} and also #{bad2}""")
+        artifact_def.custom_pom_template_content = "my pom template with a bad ref #{bad1} and also #{bad2}"
+        pomgen = pom.TemplatePomGen(ws, artifact_def, dep)
 
         with self.assertRaises(Exception) as ctx:
             generated_pom = pomgen.gen(pom.PomContentType.RELEASE)


### PR DESCRIPTION
(cherry picked from commit db2e702bc7b0fa060a8fe16ba8811c68566953b0)