### PR TITLE
Skip java_library with neverlink attribute set

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Overview
 
 The set of scripts in this repository provides a solution for:
- - Generating pom.xml files for jars built built by Bazel (typically ```java_library``` or ```java_binary``` rules)
+ - Generating pom.xml files for jars built by Bazel (typically ```java_library``` or ```java_binary``` rules)
  - Uploading the pom.xmls and jars to a Maven Artifact Repository such as Nexus (or installing them into the local Maven Repository at ~/.m2/repository)
 
 pomgen does not run as part of the Bazel build - therefore Bazel BUILD files can remain free of pom.xml related metadata.

--- a/crawl/bazel.py
+++ b/crawl/bazel.py
@@ -205,10 +205,11 @@ def _parse_conflict_resolution(json_dep_tree, mvn_install_name):
 def is_never_link_dep(repository_root_path, package):
     """
     Check if the dependency has neverlink set to 1
+    java_library with neverlink set to 1 should not be considered because required only at compilation time
+    Bazel ref: https://docs.bazel.build/versions/main/be/java.html#java_library.neverlink:~:text=on%20this%20target.-,neverlink,-Boolean%3B%20optional%3B%20default
     """
     query = "bazel query 'attr('neverlink', 1, %s)'" % package
     stdout = run_cmd(query, cwd=repository_root_path)
-    print(stdout)
     if stdout != '' and package in stdout:
         return True
 

--- a/crawl/bazel.py
+++ b/crawl/bazel.py
@@ -206,8 +206,9 @@ def is_never_link_dep(repository_root_path, package):
     """
     Check if the dependency has neverlink set to 1
     """
-    query = "bazel query 'attr(\\'neverlink\\', 1, %s)'" % package
-    stdout, _, _ = run_cmd(query, cwd=repository_root_path)
+    query = "bazel query 'attr('neverlink', 1, %s)'" % package
+    stdout = run_cmd(query, cwd=repository_root_path)
+    print(stdout)
     if stdout != '' and package in stdout:
         return True
 

--- a/crawl/bazel.py
+++ b/crawl/bazel.py
@@ -210,7 +210,4 @@ def is_never_link_dep(repository_root_path, package):
     """
     query = "bazel query 'attr('neverlink', 1, %s)'" % package
     stdout = run_cmd(query, cwd=repository_root_path)
-    if stdout != '' and package in stdout:
-        return True
-
-    return False
+    return package in stdout

--- a/crawl/bazel.py
+++ b/crawl/bazel.py
@@ -209,11 +209,8 @@ def is_never_link_dep(repository_root_path, package):
     Bazel ref: https://docs.bazel.build/versions/main/be/java.html#java_library.neverlink:~:text=on%20this%20target.-,neverlink,-Boolean%3B%20optional%3B%20default
     """
     query = "bazel query 'attr('neverlink', 1, %s)'" % package
-    try:
-        stdout = run_cmd(query, cwd=repository_root_path)
-        if stdout != '' and package in stdout:
-            return True
+    stdout = run_cmd(query, cwd=repository_root_path)
+    if stdout != '' and package in stdout:
+        return True
 
-        return False
-    except Exception as err:
-        return False
+    return False

--- a/crawl/bazel.py
+++ b/crawl/bazel.py
@@ -201,3 +201,14 @@ def _parse_conflict_resolution(json_dep_tree, mvn_install_name):
             assert actual_dep not in conflict_resolution
             conflict_resolution[actual_dep] = wanted_dep
     return conflict_resolution
+
+def is_never_link_dep(repository_root_path, package):
+    """
+    Check if the dependency is a neverlink dep
+    """
+    query = "bazel query 'attr('neverlink', 1, %s)''" % package)
+    stdout, _, _ = run_cmd(query, cwd=repository_root_path)
+    if stdout != '' and package in stdout:
+        return True
+
+    return False

--- a/crawl/bazel.py
+++ b/crawl/bazel.py
@@ -206,7 +206,7 @@ def is_never_link_dep(repository_root_path, package):
     """
     Check if the dependency is a neverlink dep
     """
-    query = "bazel query 'attr('neverlink', 1, %s)''" % package)
+    query = "bazel query 'attr('neverlink', 1, %s)" % package
     stdout, _, _ = run_cmd(query, cwd=repository_root_path)
     if stdout != '' and package in stdout:
         return True

--- a/crawl/bazel.py
+++ b/crawl/bazel.py
@@ -204,9 +204,9 @@ def _parse_conflict_resolution(json_dep_tree, mvn_install_name):
 
 def is_never_link_dep(repository_root_path, package):
     """
-    Check if the dependency is a neverlink dep
+    Check if the dependency has neverlink set to 1
     """
-    query = "bazel query 'attr('neverlink', 1, %s)" % package
+    query = "bazel query 'attr(\\'neverlink\\', 1, %s)'" % package
     stdout, _, _ = run_cmd(query, cwd=repository_root_path)
     if stdout != '' and package in stdout:
         return True

--- a/crawl/bazel.py
+++ b/crawl/bazel.py
@@ -209,8 +209,11 @@ def is_never_link_dep(repository_root_path, package):
     Bazel ref: https://docs.bazel.build/versions/main/be/java.html#java_library.neverlink:~:text=on%20this%20target.-,neverlink,-Boolean%3B%20optional%3B%20default
     """
     query = "bazel query 'attr('neverlink', 1, %s)'" % package
-    stdout = run_cmd(query, cwd=repository_root_path)
-    if stdout != '' and package in stdout:
-        return True
+    try:
+        stdout = run_cmd(query, cwd=repository_root_path)
+        if stdout != '' and package in stdout:
+            return True
 
-    return False
+        return False
+    except Exception as err:
+        return False

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -137,7 +137,7 @@ class Workspace:
 
             maven_artifact_def = self.parse_maven_artifact_def(package_path)
             if maven_artifact_def is None:
-                if bazel.is_never_link_dep(self.repo_root_path, package_path):
+                if bazel.is_never_link_dep(self.repo_root_path, dep_label):
                     return None
 
                 raise Exception("no BUILD.pom file in package [%s]" % package_path)

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -144,7 +144,7 @@ class Workspace:
                 if package_path.startswith(excluded_dependency_path):
                     return None
 
-             if self.is_never_link_dep(package_path):
+            if self.is_never_link_dep(package_path):
                 return None
 
             maven_artifact_def = self.parse_maven_artifact_def(package_path)

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -143,8 +143,12 @@ class Workspace:
             for excluded_dependency_path in self.excluded_dependency_paths:
                 if package_path.startswith(excluded_dependency_path):
                     return None
+
+             if self.is_never_link_dep(package_path):
+                return None
+
             maven_artifact_def = self.parse_maven_artifact_def(package_path)
-            if maven_artifact_def is None and not self.is_never_link_dep(package_path):
+            if maven_artifact_def is None:
                 raise Exception("no BUILD.pom file in package [%s]" % package_path)
             else:
                 return dependency.new_dep_from_maven_artifact_def(maven_artifact_def, target_name)

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -66,7 +66,7 @@ class Workspace:
         """
         Check if the dependency is a neverlink dep
         """
-        if 'lombok' in package
+        if 'lombok' in package:
             return True
 
         return False

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -66,7 +66,7 @@ class Workspace:
         """
         Check if the dependency is a neverlink dep
         """
-        if 'lombok' in package:
+        if 'tools/common/lombok' in package:
             return True
 
         return False

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -135,7 +135,7 @@ class Workspace:
                 if package_path.startswith(excluded_dependency_path):
                     return None
 
-            if bazel.is_never_link_dep(package_path):
+            if bazel.is_never_link_dep(self.repo_root_path, package_path):
                 return None
 
             maven_artifact_def = self.parse_maven_artifact_def(package_path)

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -62,15 +62,6 @@ class Workspace:
         self._package_to_artifact_def[package] = art_def
         return art_def
 
-    def is_never_link_dep(self, package):
-        """
-        Check if the dependency is a neverlink dep
-        """
-        if 'tools/common/lombok' in package:
-            return True
-
-        return False
-
     def parse_dep_labels(self, dep_labels):
         """
         Given a list of Bazel labels, returns a list of Dependency instances.
@@ -144,7 +135,7 @@ class Workspace:
                 if package_path.startswith(excluded_dependency_path):
                     return None
 
-            if self.is_never_link_dep(package_path):
+            if bazel.is_never_link_dep(package_path):
                 return None
 
             maven_artifact_def = self.parse_maven_artifact_def(package_path)

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -62,6 +62,12 @@ class Workspace:
         self._package_to_artifact_def[package] = art_def
         return art_def
 
+    def is_never_link_dep(self, package):
+        """
+        Check if the dependency is a neverlink dep
+        """
+        return if 'lombok' in package
+
     def parse_dep_labels(self, dep_labels):
         """
         Given a list of Bazel labels, returns a list of Dependency instances.
@@ -135,7 +141,7 @@ class Workspace:
                 if package_path.startswith(excluded_dependency_path):
                     return None
             maven_artifact_def = self.parse_maven_artifact_def(package_path)
-            if maven_artifact_def is None:
+            if maven_artifact_def is None and not self.is_never_link_dep(package_path):
                 raise Exception("no BUILD.pom file in package [%s]" % package_path)
             else:
                 return dependency.new_dep_from_maven_artifact_def(maven_artifact_def, target_name)

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -135,11 +135,11 @@ class Workspace:
                 if package_path.startswith(excluded_dependency_path):
                     return None
 
-            if bazel.is_never_link_dep(self.repo_root_path, package_path):
-                return None
-
             maven_artifact_def = self.parse_maven_artifact_def(package_path)
             if maven_artifact_def is None:
+                if bazel.is_never_link_dep(self.repo_root_path, package_path):
+                    return None
+
                 raise Exception("no BUILD.pom file in package [%s]" % package_path)
             else:
                 return dependency.new_dep_from_maven_artifact_def(maven_artifact_def, target_name)

--- a/crawl/workspace.py
+++ b/crawl/workspace.py
@@ -66,7 +66,10 @@ class Workspace:
         """
         Check if the dependency is a neverlink dep
         """
-        return if 'lombok' in package
+        if 'lombok' in package
+            return True
+
+        return False
 
     def parse_dep_labels(self, dep_labels):
         """

--- a/examples/compile-only-dependencies/README.md
+++ b/examples/compile-only-dependencies/README.md
@@ -1,0 +1,42 @@
+# Compilation time only deps should not be evaluated by pomgen
+
+There are some dependencies that are needed only at compilation time, like for example Lombok.
+This kind of dependencies can be managed differently by Bazel adding the attribute `neverlink = 1` to `java_library`.
+Most likely those dependencies won't have a `BUILD.pom` file, so they have to be ignored by `pomgen`.
+
+### Try this example
+
+From the root of the repository:
+
+```
+bazel build examples/dependency-management/...
+```
+
+```
+bazel run @pomgen//maven -- -a pomgen,install -t examples/dependency-management
+```
+
+Now look under your `$HOME/.m2/repository`:
+
+The usual `jar` packaging pom is at:
+`com/pomgen/depman/example/juicer/3.0.0-SNAPSHOT/juicer-3.0.0-SNAPSHOT.pom`
+
+The dependency management pom (`pom` packaging) is at:
+`com/pomgen/depman/example/juicer.depmanagement/3.0.0-SNAPSHOT/juicer.depmanagement-3.0.0-SNAPSHOT.pom`
+
+
+The `<dependencyManagement>` in the dependency management pom can be used (imported) the following way:
+
+```
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>com.pomgen.depman.example</groupId>
+            <artifactId>juicer.depmanagement</artifactId>
+            <version>3.0.0-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+<dependencyManagement>
+```

--- a/examples/compile-only-dependencies/README.md
+++ b/examples/compile-only-dependencies/README.md
@@ -9,11 +9,11 @@ Most likely those dependencies won't have a `BUILD.pom` file, so they have to be
 From the root of the repository:
 
 ```
-bazel build examples/dependency-management/...
+bazel build examples/compile-only-dependencies/...
 ```
 
 ```
 bazel run @pomgen//maven -- -a pomgen,install -t examples/compile-only-dependencies
 ```
 
-It should pass even if `examples/compile-only-dependencies/fancy` has no `BUILD.pom` file.
+It should pass even if `examples/compile-only-dependencies/fancy` has no `BUILD.pom` file and the generated pom will not include the `neverlink` dependency.

--- a/examples/compile-only-dependencies/README.md
+++ b/examples/compile-only-dependencies/README.md
@@ -13,30 +13,7 @@ bazel build examples/dependency-management/...
 ```
 
 ```
-bazel run @pomgen//maven -- -a pomgen,install -t examples/dependency-management
+bazel run @pomgen//maven -- -a pomgen,install -t examples/compile-only-dependencies
 ```
 
-Now look under your `$HOME/.m2/repository`:
-
-The usual `jar` packaging pom is at:
-`com/pomgen/depman/example/juicer/3.0.0-SNAPSHOT/juicer-3.0.0-SNAPSHOT.pom`
-
-The dependency management pom (`pom` packaging) is at:
-`com/pomgen/depman/example/juicer.depmanagement/3.0.0-SNAPSHOT/juicer.depmanagement-3.0.0-SNAPSHOT.pom`
-
-
-The `<dependencyManagement>` in the dependency management pom can be used (imported) the following way:
-
-```
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>com.pomgen.depman.example</groupId>
-            <artifactId>juicer.depmanagement</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-<dependencyManagement>
-```
+It should pass even if `examples/compile-only-dependencies/fancy` has no `BUILD.pom` file.

--- a/examples/compile-only-dependencies/coollib/BUILD
+++ b/examples/compile-only-dependencies/coollib/BUILD
@@ -6,8 +6,3 @@ java_library(
     ]
 )
 
-java_binary(
-    name = "make-coollib",
-    runtime_deps = [":coollib"],
-    main_class = "com.pomgen.example.Main",
-)

--- a/examples/compile-only-dependencies/coollib/BUILD
+++ b/examples/compile-only-dependencies/coollib/BUILD
@@ -1,0 +1,13 @@
+java_library(
+    name = "coollib",
+    srcs = glob(["src/main/java/**/*.java"]),
+    deps = ["//examples/compile-only-dependencies/fancy",
+            "@maven//:com_google_guava_guava",
+    ]
+)
+
+java_binary(
+    name = "make-coollib",
+    runtime_deps = [":coollib"],
+    main_class = "com.pomgen.example.Main",
+)

--- a/examples/compile-only-dependencies/coollib/MVN-INF/BUILD.pom
+++ b/examples/compile-only-dependencies/coollib/MVN-INF/BUILD.pom
@@ -1,0 +1,11 @@
+maven_artifact(
+    group_id = "com.pomgen.depman.example",
+    artifact_id = "coollib",
+    version = "3.0.0-SNAPSHOT",
+    pom_generation_mode = "dynamic",
+    generate_dependency_management_pom = True,
+)
+
+maven_artifact_update(
+    version_increment_strategy = "minor",
+)

--- a/examples/compile-only-dependencies/coollib/MVN-INF/BUILD.pom
+++ b/examples/compile-only-dependencies/coollib/MVN-INF/BUILD.pom
@@ -1,9 +1,8 @@
 maven_artifact(
-    group_id = "com.pomgen.depman.example",
+    group_id = "com.pomgen.cool.example",
     artifact_id = "coollib",
     version = "3.0.0-SNAPSHOT",
     pom_generation_mode = "dynamic",
-    generate_dependency_management_pom = True,
 )
 
 maven_artifact_update(

--- a/examples/compile-only-dependencies/coollib/src/main/java/com/pomgen/example/Cool.java
+++ b/examples/compile-only-dependencies/coollib/src/main/java/com/pomgen/example/Cool.java
@@ -1,7 +1,7 @@
 package com.pomgen.example;
 
 /**
- * A Juicer produces either Vegetable or Fruit juice.
+ * A very cool library as you can see
  */
 public class Cool {
 

--- a/examples/compile-only-dependencies/coollib/src/main/java/com/pomgen/example/Cool.java
+++ b/examples/compile-only-dependencies/coollib/src/main/java/com/pomgen/example/Cool.java
@@ -1,0 +1,12 @@
+package com.pomgen.example;
+
+/**
+ * A Juicer produces either Vegetable or Fruit juice.
+ */
+public class Cool {
+
+    public void stuff() {
+        System.out.println("I'm cool!");
+    }
+
+}

--- a/examples/compile-only-dependencies/coollib/src/main/java/com/pomgen/example/Main.java
+++ b/examples/compile-only-dependencies/coollib/src/main/java/com/pomgen/example/Main.java
@@ -1,0 +1,9 @@
+package com.pomgen.example;
+
+public class Main {
+
+    public static void main(String[] args) {
+        Cool cool = new Cool();
+        cool.stuff();
+    }
+}

--- a/examples/compile-only-dependencies/fancy/BUILD
+++ b/examples/compile-only-dependencies/fancy/BUILD
@@ -1,0 +1,6 @@
+java_library(
+    name = "fancy",
+    neverlink = 1,
+    srcs = glob(["src/main/java/**/*.java"]),
+    visibility = ["//visibility:public"],
+)

--- a/examples/compile-only-dependencies/fancy/src/main/java/com/pomgen/example/FancyCompileOnly.java
+++ b/examples/compile-only-dependencies/fancy/src/main/java/com/pomgen/example/FancyCompileOnly.java
@@ -1,0 +1,11 @@
+package com.pomgen.example;
+
+/**
+ * A FancyCompileOnly
+ */
+public class FancyCompileOnly {
+
+    public void doSomethingAmazing() {
+        System.out.println("I'm cool!");
+    }
+}

--- a/examples/compile-only-dependencies/fancy/src/main/java/com/pomgen/example/Main.java
+++ b/examples/compile-only-dependencies/fancy/src/main/java/com/pomgen/example/Main.java
@@ -1,0 +1,9 @@
+package com.pomgen.example;
+
+public class Main {
+
+    public static void main(String[] args) {
+        FancyCompileOnly fancy = new FancyCompileOnly();
+        fancy.doSomethingAmazing();
+    }
+}

--- a/tests/workspacetest.py
+++ b/tests/workspacetest.py
@@ -389,7 +389,7 @@ released_maven_artifact(
         mii.get_maven_install_names_and_paths = lambda r: [(maven_install_name, "some/repo/path",)]
         return mii
 
-    def _write_build_file(self, repo_root_path, package_rel_path, neverlinkAttribute = False):
+    def _write_build_file(self, repo_root_path, package_rel_path, neverlink_attr_enabled = False):
         build_file = """
 java_plugin(
     name = "lombok-plugin",
@@ -406,8 +406,8 @@ java_library(
     exported_plugins = [":lombok-plugin"],
     visibility = ["//visibility:public"],
 )
-""" % (1 if neverlinkAttribute == True else 0)
-        print(build_file)
+""" % (0 if neverlink_attr_enabled == False else 1)
+
         path = os.path.join(repo_root_path, package_rel_path)
         if not os.path.exists(path):
             os.makedirs(path)


### PR DESCRIPTION
This PR is meant to make pomgen not evaluate those libraries that are required only at compilation time.

I have also added an example in `examples/compile-only-dependencies`