### PR TITLE
Adding support for Calendar Versioning to pomgen

### DIFF
--- a/common/version.py
+++ b/common/version.py
@@ -15,7 +15,7 @@ import re
 
 
 version_re = re.compile("(^.*version *= *[\"'])(.*?)([\"'].*)$", re.S)
-
+VERSION_INCREMENT_STRATEGIES = ("major", "minor", "patch", "calver", )
 
 def get_version_increment_strategy(build_pom_content):
     """

--- a/docs/mdfiles.md
+++ b/docs/mdfiles.md
@@ -44,7 +44,11 @@ The `<version>` for the generated pom.xml.
 
 ##### maven_artifact_update.version_increment_strategy
 
-Controls how the version attribute is incremented, possible values are `major|minor|patch` [see CI setup](ci.md).
+Controls how the version attribute is incremented, possible values are `major|minor|patch|calver` [see CI setup](ci.md).
+
+Given a current version of `1.2.3`, the `major`, `minor`, and `patch` incrementing strategies would produce versions `2.2.3`, `1.3.3`, and `1.2.4` respectively.
+
+Given a current version of `20230605.1`, the `calver` incrementing strategy would produce `<todaydate>.1` (or `<todaydate>.2` if the current version is already `<todaydate>.1`).
 
 #### Optional Attributes
 

--- a/examples/hello-world/wintervegetables/MVN-INF/BUILD.pom
+++ b/examples/hello-world/wintervegetables/MVN-INF/BUILD.pom
@@ -1,10 +1,10 @@
 maven_artifact(
     group_id = "com.pomgen.example",
     artifact_id = "wintervegetables",
-    version = "2.0.0-SNAPSHOT",
+    version = "20200416.1-SNAPSHOT",
     pom_generation_mode = "dynamic",
 )
 
 maven_artifact_update(
-    version_increment_strategy = "minor",
+    version_increment_strategy = "calver",
 )

--- a/tests/versiontest.py
+++ b/tests/versiontest.py
@@ -7,6 +7,7 @@ For full license text, see the LICENSE file in the repo root or https://opensour
 
 import unittest
 from common import version
+from datetime import datetime, timezone
 
 
 class VersionTest(unittest.TestCase):
@@ -174,6 +175,26 @@ released_maven_artifact(
         s = version.get_version_increment_strategy(build_pom_content)
         self.assertEqual("1.1.1-scone_70x-SNAPSHOT", s("1.1.0-scone_70x-SNAPSHOT"))
 
+    def test_get_next_version__calver_new_day(self):
+        build_pom_content = self._get_build_pom("calver")
+        s = version.get_version_increment_strategy(build_pom_content)
+        self.assertEqual("%s.1-whatever-this-is" % self._today(), s("3.2.0-whatever-this-is"))
+
+    def test_get_next_version__calver_new_day_take_two(self):
+        build_pom_content = self._get_build_pom("calver")
+        s = version.get_version_increment_strategy(build_pom_content)
+        self.assertEqual("%s.1-whatever-this-is" % self._today(), s("20200320.1-whatever-this-is"))
+
+    def test_get_next_version__calver_same_day(self):
+        build_pom_content = self._get_build_pom("calver")
+        s = version.get_version_increment_strategy(build_pom_content)
+        self.assertEqual("%s.2-whatever-this-is" % self._today(), s("%s.1-whatever-this-is" % self._today()))
+
+    def test_get_next_version__calver_same_day_with_lots_of_updates(self):
+        build_pom_content = self._get_build_pom("calver")
+        s = version.get_version_increment_strategy(build_pom_content)
+        self.assertEqual("%s.10-whatever-this-is" % self._today(), s("%s.9-whatever-this-is" % self._today()))
+
     def test_unknown_version_increment_strategy(self):
         build_pom_content = self._get_build_pom("lucy in the sky with diamonds")
         with self.assertRaises(Exception) as ctx:
@@ -194,6 +215,9 @@ maven_artifact_update(
 )
 """
         return build_pom % version_increment_strategy
+
+    def _today(self):
+        return datetime.now(timezone.utc).strftime('%Y%m%d')
 
 
 if __name__ == '__main__':

--- a/update.py
+++ b/update.py
@@ -12,6 +12,7 @@ from common import argsupport
 from common import common
 from common import logger
 from common import mdfiles
+from common import version
 from config import config
 from crawl import bazel
 from update import buildpomupdate
@@ -20,7 +21,6 @@ import os
 import sys
 
 
-VERSION_INCREMENT_STRATEGIES = ("major", "minor", "patch",)
 
 
 def _parse_arguments(args):
@@ -31,7 +31,7 @@ def _parse_arguments(args):
     parser.add_argument("--new_version", type=str, required=False,
         help="The value of the version to write into BUILD.pom files")
     parser.add_argument("--new_version_increment_strategy", type=str,
-        required=False, choices = VERSION_INCREMENT_STRATEGIES,
+        required=False, choices = version.VERSION_INCREMENT_STRATEGIES,
         help="The value of the version_increment_strategy to write into BUILD.pom files")
     parser.add_argument("--new_released_version", type=str, required=False,
         help="The value of the version to write into BUILD.pom.released files")


### PR DESCRIPTION
For projects that need to coordinate multiple changes across multiple code repositories, it can be frustrating to keep track of which semantic version correspond with which other semantic version between those repositories. One solution is to version these projects using calendar versioning - AKA use the date as the version instead of an arbitrary incrementing number that may or may not make sense. This makes it trivial to know which versions across those projects are likely related to one another, or at least how old they are.

This change provides the `"calver"` version incrementing strategy which produces a new version following ISO 8601 format for the date, and then an incrementing minor version number starting at `1` and incrementing for every version produced in the same day (rare, but they happen).

As an example, for a given `project` that has a current version `20230604.1-my-project`, incrementing it twice on June 5th and once again on June 6th will produce the following three versions:
`20230605.1-my-project`
`20230605.2-my-project`
`20230606.1-my-project`

In this change, UTC timezone is used for date calculation for consistency, which can result in versions being produced that look like they're in the "future" or "past" from your current timezone. Not sure if that needs to be called out anywhere.