### PR TITLE
Next release version recomputes the calver string

### DIFF
--- a/common/version_increment_strategy.py
+++ b/common/version_increment_strategy.py
@@ -150,6 +150,20 @@ class PatchVersionIncrementStrategy(DefaultVersionIncrementStrategy):
 
 class CalverVersionIncrementStrategy(DefaultVersionIncrementStrategy):
 
+    def get_next_release_version(self, current_version):
+        """
+        The next release version for Calver re-computes the version instead of
+        only removing the -SNAPSHOT qualifier, because we want to use the
+        current date in the version string (the date when the release
+        actually happened).
+
+        For simplicity sake, we just get next dev version (which already
+        recomputes the version) and remove the -SNAPSHOT qualifier.
+        """
+        release_version = self.get_next_development_version(current_version)
+        i = release_version.index(SNAPSHOT_QUAL)
+        return release_version[0:i]
+
     def get_next_version__hook(self, current_version):
         """
         Given a current version of `20230605.1`, produces <todaydate>.1

--- a/tests/version_increment_strategy_test.py
+++ b/tests/version_increment_strategy_test.py
@@ -59,9 +59,11 @@ class VersionIncrementStrategyTest(unittest.TestCase):
     def test_calver_version(self):
         s = vis.get_version_increment_strategy("calver")
 
-        self.assertEqual("3.2.0", s.get_next_release_version("3.2.0-SNAPSHOT"))
-        self.assertEqual("20200320.1", s.get_next_release_version("20200320.1"))
-        self.assertEqual("20200320.1", s.get_next_release_version("20200320.1-SNAPSHOT"))
+        self.assertEqual("%s.1" % _today(), s.get_next_release_version("0-SNAPSHOT"))
+        self.assertEqual("%s.1" % _today(), s.get_next_release_version("0"))
+        self.assertEqual("%s.1-qual" % _today(), s.get_next_release_version("0-qual-SNAPSHOT"))
+        self.assertEqual("%s.1-qual" % _today(), s.get_next_release_version("0-qual"))
+        self.assertEqual("%s.3" % _today(), s.get_next_release_version("%s.2-SNAPSHOT" % _today()))
 
         self.assertEqual("%s.1-SNAPSHOT" % _today(), s.get_next_development_version("3.2.0"))
         self.assertEqual("%s.1-SNAPSHOT" % _today(), s.get_next_development_version("20200320.1"))


### PR DESCRIPTION
Output of `bazel run //:query -- --package examples/hello-world/wintervegetables --library_release_plan_json`:
```
  {
    "library_path": "examples/hello-world/wintervegetables",
    "version": "20200416.1-SNAPSHOT",
    "released_version": null,
    "requires_release": true,
    "release_reason": "artifact has never been released",
    "proposed_release_version": "20230628.1",
    "proposed_next_dev_version": "20230628.1-SNAPSHOT"
  },
```