### PR TITLE
Refactor PomContentType to ManifestContentType

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Etiquette
+
+- Keep answers short
+- Ask if something is unclear, do not assume anything
+- Confirm plan before making code changes
+
+
+# Verification of code changes
+
+For verification of all code changes made, always run:
+
+bazel test //... from the root directory (this directory)
+The command above should complete without errors
+
+bazel run //:gen -- --package examples --destdir tests/examples_goldfiles
+The command above should complete without errors
+There should be no diffs un the tests/examples_goldfiles directory
+
+ruff check src tests misc
+The command above should complete without errors

--- a/misc/extdeps_pomgen.py
+++ b/misc/extdeps_pomgen.py
@@ -14,12 +14,11 @@ import common.label as labelm
 import config.config as config
 import crawl.buildpom as buildpom
 import crawl.pomcontent as pomcontent
-import generate.impl.pom.dependency as dependency
+import generate
 import generate.impl.pom.dependencymd as dependencymdm
 import generate.impl.pom.maveninstallinfo as maveninstallinfo
 import generate.impl.pom.pom as pom
 import generate.impl.pom.pomgenerationstrategy as pomgenerationstrategy
-import os
 import sys
 
 
@@ -127,7 +126,7 @@ def main(args):
     pomgen = ThirdPartyDepsPomGen(
         artifact_def, dependencies, cfg.pom_template, dependencymd)
 
-    return pomgen.generate_manifest(pom.PomContentType.RELEASE)
+    return pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
 
 if __name__ == "__main__":

--- a/src/crawl/crawler.py
+++ b/src/crawl/crawler.py
@@ -17,7 +17,7 @@ import crawl.bazel as bazel
 import crawl.buildpom as buildpom
 import crawl.releasereason as releasereason
 import difflib
-import generate.impl.pom.pom as pom
+import generate
 import generate.impl.pom.pomparser as pomparser
 import os
 
@@ -266,7 +266,7 @@ class Crawler:
             art_def = ctx.artifact_def
             if not art_def.requires_release and art_def.released_pom_content is not None:
                 generator = art_def.generation_strategy.new_generator(ctx)
-                goldfile_manifest = generator.generate_manifest(pom.PomContentType.GOLDFILE)
+                goldfile_manifest = generator.generate_manifest(generate.ManifestContentType.GOLDFILE)
                 # TODO - do not hardcode pom logic
                 current_manifest = pomparser.format_for_comparison(goldfile_manifest)
                 previous_manifest = pomparser.format_for_comparison(art_def.released_pom_content)

--- a/src/generate/__init__.py
+++ b/src/generate/__init__.py
@@ -2,6 +2,26 @@ from abc import ABC, abstractmethod
 import os
 
 
+class ManifestContentType:
+    """
+    Available manifest content types:
+
+      RELEASE - this is the default, standard manifest, based on BUILD file or
+          template content.
+
+      GOLDFILE - this manifest content is meant for comparing against another
+                 previously generated manifest (the "goldfile" manifest). This content
+                 type differs from the default RELEASE type in the following
+                 ways:
+                   - dependencies are explictly ordered (default is BUILD order)
+                   - versions of monorepo-based dependencies are removed
+    """
+    RELEASE = 0
+    GOLDFILE = 1
+
+    MASKED_VERSION = "***"
+
+
 class AbstractDependency(ABC):
     """
     TODO for source dependencies, abstract here how we decide whether a 

--- a/src/pomgen.py
+++ b/src/pomgen.py
@@ -20,8 +20,8 @@ import crawl.crawler as crawlerm
 import crawl.libaggregator as libaggregator
 import crawl.pomcontent as pomcontentm
 import crawl.workspace as workspace
+import generate
 import generate.generationstrategyfactory as generationstrategyfactory
-import generate.impl.pom.pom as pom
 import os
 import sys
 
@@ -77,11 +77,11 @@ def main(args):
             # write it using the mdfiles module, which ensures it goes 
             # into the proper location within the specified bazel package
             if args.pom_goldfile:
-                pom_content = pomgen.generate_manifest(pom.PomContentType.GOLDFILE)
+                pom_content = pomgen.generate_manifest(generate.ManifestContentType.GOLDFILE)
                 pom_goldfile_path = mdfiles.write_file(pom_content, output_dir, pomgen.bazel_package, mdfiles.POM_XML_RELEASED_FILE_NAME)
                 logger.info("Wrote goldfile manifest to [%s]" % pom_goldfile_path)
             else:
-                pom_content = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+                pom_content = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
                 pom_path = os.path.join(
                     pom_dest_dir, "%s.%s" % (
                         gen_strategy.base_manifest_filename,
@@ -89,7 +89,7 @@ def main(args):
                 _write_file(pom_path, pom_content)
                 logger.info("Wrote manifest file to [%s]" % pom_path)
                 for i, companion_pomgen in enumerate(pomgen.get_companion_generators()):
-                    pom_content = companion_pomgen.generate_manifest(pom.PomContentType.RELEASE)
+                    pom_content = companion_pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
                     pom_path = os.path.join(pom_dest_dir, 
                         "%s_companion%s.%s" % (
                             gen_strategy.base_manifest_filename, i,

--- a/tests/generate/impl/pom/pomtest.py
+++ b/tests/generate/impl/pom/pomtest.py
@@ -9,6 +9,7 @@ For full license text, see the LICENSE file in the repo root or https://opensour
 import common.genmode as genmode
 import crawl.buildpom as buildpom
 import crawl.pomcontent as pomcontent
+import generate
 import generate.impl.pom.dependency as dependency
 import generate.impl.pom.dependencymd as dependencymdm
 import generate.impl.pom.pom as pom
@@ -67,7 +68,7 @@ class PomTest(unittest.TestCase):
         pomgen.register_dependencies(deps)
         # skipped_transitive (see above) is NOT added
         pomgen.register_dependencies_transitive_closure__artifact([self.t1_dep, self.t2_dep])
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertIn("""<groupId>g1</groupId>
     <artifactId>a2</artifactId>
@@ -185,7 +186,7 @@ class PomTest(unittest.TestCase):
         pomgen = pom.DynamicPomGen(artifact_def, pom_template, pc,
                                    self.dependencymd)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
         self.assertEqual(exepcted_pom, generated_pom)
 
     def test_dynamic_pom__remove_description_token_if_no_value(self):
@@ -206,7 +207,7 @@ class PomTest(unittest.TestCase):
         pomgen = pom.DynamicPomGen(artifact_def, pom_template, pc,
                                    self.dependencymd)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertEqual(exepcted_pom, generated_pom)
 
@@ -227,7 +228,7 @@ class PomTest(unittest.TestCase):
                                    self.dependencymd)
         pomgen.register_dependencies([self.guava_dep])
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertIn("""<dependency>
             <groupId>com.google.guava</groupId>
@@ -252,7 +253,7 @@ class PomTest(unittest.TestCase):
         dep = dependency.new_dep_from_maven_artifact_def(dep_art_def)
 
         dep_element, _ = pomgen._gen_dependency_element(
-            pom.PomContentType.RELEASE, dep, "", indent=0, close_element=True)
+            generate.ManifestContentType.RELEASE, dep, "", indent=0, close_element=True)
         
         self.assertIn("""<dependency>
     <groupId>class-group</groupId>
@@ -271,7 +272,7 @@ class PomTest(unittest.TestCase):
                                    pomcontent.NOOP,
                                    self.dependencymd)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertNotIn("dependencies", generated_pom)
 
@@ -290,7 +291,7 @@ class PomTest(unittest.TestCase):
         deps = [self.guava_dep, self.aop_dep]
         pomgen.register_dependencies(deps)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.GOLDFILE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.GOLDFILE)
 
         self.assertIn("""<groupId>g1</groupId>
     <artifactId>a2</artifactId>
@@ -326,7 +327,7 @@ monorepo artifact version #{version}
         pomgen = pom.TemplatePomGen(artifact_def, external_dependencies,
                                     self.dependencymd)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertIn("unqualified 1.2.3", generated_pom)
         self.assertIn("qualified 1.2.3", generated_pom)
@@ -344,7 +345,7 @@ monorepo artifact version #{version}
         pomgen = pom.TemplatePomGen(artifact_def, [], self.dependencymd)
         pomgen.register_dependencies_transitive_closure__library(set([srpc_dep]))
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
         
         self.assertIn("srpc 5.6.7", generated_pom)
 
@@ -371,7 +372,7 @@ monorepo artifact version #{version}
         pomgen = pom.TemplatePomGen(artifact_def, external_dependencies,
                                     self.dependencymd)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertIn("1 v1 1.0.0", generated_pom)
         self.assertIn("2 v2 1.0.0", generated_pom)
@@ -396,7 +397,7 @@ v2 #{@maven2//:org_apache_maven_mult_versions.version}
         pomgen = pom.TemplatePomGen(artifact_def, external_dependencies,
                                     self.dependencymd)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertIn("v1 1.0.0", generated_pom)
         self.assertIn("v2 2.0.0", generated_pom)
@@ -420,7 +421,7 @@ v2 #{@maven2//:org_apache_maven_mult_versions.version}
                                     self.dependencymd)
 
         with self.assertRaises(Exception) as ctx:
-            pomgen.generate_manifest(pom.PomContentType.RELEASE)
+            pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
         self.assertIn("has unresolvable references", str(ctx.exception))
         self.assertIn("['org_apache_maven_mult_versions.version']", str(ctx.exception))
 
@@ -432,7 +433,7 @@ v2 #{@maven2//:org_apache_maven_mult_versions.version}
                                     self.dependencymd)
 
         with self.assertRaises(Exception) as ctx:
-            pomgen.generate_manifest(pom.PomContentType.RELEASE)
+            pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
         self.assertIn("has unresolvable references", str(ctx.exception))
         self.assertIn("['org.apache.maven:mult-versions:version']", str(ctx.exception))
 
@@ -454,7 +455,7 @@ v2 #{@maven2//:org_apache_maven_mult_versions.version}
         d = dependency.MonorepoDependency(art)
         pomgen.register_dependencies_transitive_closure__library(set([d]))
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         # the Bazel_package guava version should be picked
         self.assertIn("29.0", generated_pom)
@@ -469,7 +470,7 @@ v2 #{@maven2//:org_apache_maven_mult_versions.version}
         artifact_def.custom_pom_template_content = "srpc #{com.google.guava:guava:version}"
         pomgen = pom.TemplatePomGen(artifact_def, [self.guava_dep],
                                     self.dependencymd)
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         # the maven_install guava version should be picked
         self.assertIn("23.0", generated_pom)
@@ -495,7 +496,7 @@ srpc #{com.grail.srpc:srpc-api:version}
         pomgen = pom.TemplatePomGen(artifact_def, [self.logback_dep],
                                     self.dependencymd)
         pomgen.register_dependencies_transitive_closure__library(set([srpc_dep]))
-        generated_pom = pomgen.generate_manifest(pomcontenttype=pom.PomContentType.GOLDFILE)
+        generated_pom = pomgen.generate_manifest(pomcontenttype=generate.ManifestContentType.GOLDFILE)
 
         self.assertIn("this artifact version ***", generated_pom)
         self.assertIn("logback coord 1.2.3", generated_pom)
@@ -531,7 +532,7 @@ __pomgen.end_dependency_customization__
         artifact_def.custom_pom_template_content = pom_template
         pomgen = pom.TemplatePomGen(artifact_def, [], self.dependencymd)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertEqual(expected_pom, generated_pom)
 
@@ -586,7 +587,7 @@ __pomgen.end_dependency_customization__
         artifact_def.custom_pom_template_content = pom_template
         pomgen = pom.TemplatePomGen(artifact_def, [], self.dependencymd)
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertEqual(expected_pom, generated_pom)
 
@@ -633,7 +634,7 @@ __pomgen.end_dependency_customization__
         external_dep = dependency.ThirdPartyDependency("name", "cg", "ca", "0.0.1")
         pomgen.register_dependencies_transitive_closure__library(set([external_dep, internal_dep]))
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertEqual(expected_pom, generated_pom)
 
@@ -700,7 +701,7 @@ __pomgen.end_dependency_customization__
         crawled_dep = dependency.ThirdPartyDependency("name", "cg", "ca", "0.0.1")
         pomgen.register_dependencies_transitive_closure__library(set([crawled_dep]))
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertEqual(expected_pom, generated_pom)
 
@@ -749,7 +750,7 @@ __pomgen.end_dependency_customization__
         crawled_dep = dependency.ThirdPartyDependency("name", "cg", "ca", "0.0.1")
         pomgen.register_dependencies_transitive_closure__library(set([crawled_dep]))
 
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertEqual(expected_pom, generated_pom)
 
@@ -764,7 +765,7 @@ __pomgen.end_dependency_customization__
         pomgen = pom.TemplatePomGen(artifact_def, [], self.dependencymd)
 
         with self.assertRaises(Exception) as ctx:
-            pomgen.generate_manifest(pom.PomContentType.RELEASE)
+            pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
 
         self.assertIn("bad1", str(ctx.exception))
         self.assertIn("bad2", str(ctx.exception))
@@ -781,7 +782,7 @@ __pomgen.end_dependency_customization__
         force = dependency.new_dep_from_maven_art_str("force:commons:1", "forc")
 
         pomgen.register_dependencies_transitive_closure__artifact((guava, force,))
-        generated_pom = pomgen.generate_manifest(pom.PomContentType.RELEASE)
+        generated_pom = pomgen.generate_manifest(generate.ManifestContentType.RELEASE)
         
         self.assertIn("<packaging>pom</packaging>", generated_pom)
         self.assertIn("<dependencyManagement>", generated_pom)


### PR DESCRIPTION
Move PomContentType class from pom.py to generate/__init__.py and rename to ManifestContentType to make it more generic and available across the codebase. Update all imports and references accordingly.

🤖 Generated with [Claude Code](https://claude.ai/code)