### PR TITLE
Refactor configvalueloader to support bulk loading

### DIFF
--- a/misc/BUILD
+++ b/misc/BUILD
@@ -1,12 +1,28 @@
-load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_test")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library")
 
+
+py_library(
+    name = "extdeps_pomgen_lib",
+    srcs = ["extdeps_pomgen.py"],
+    deps = ["//:poppy_lib"],
+    imports = ["../src", "."],
+    visibility = ["//misc/tests:__pkg__"],
+)
 
 py_binary(
     name = "extdeps",
-    srcs = ["extdeps_pomgen.py"],
     main = "extdeps_pomgen.py",
-    deps = ["//:poppy_lib"],
+    srcs = ["extdeps_pomgen.py"],
+    deps = [":extdeps_pomgen_lib"],
     imports = ["../src"],
+)
+
+py_library(
+    name = "configvalueloader_lib",
+    srcs = ["configvalueloader.py"],
+    deps = ["//:poppy_lib"],
+    imports = ["../src", "."],
+    visibility = ["//misc/tests:__pkg__"],
 )
 
 py_binary(
@@ -14,14 +30,5 @@ py_binary(
     srcs = ["configvalueloader.py"],
     deps = ["//:poppy_lib"],
     imports = ["../src"],
-)
-
-py_test(
-    name = "extdeps_pomgentest",
-    srcs = ["extdeps_pomgen.py",
-            "tests/extdeps_pomgentest.py"],
-    deps = ["//:poppy_lib"],
-    imports = [".", "../src"],
-    size = "small",
 )
 

--- a/misc/configvalueloader.py
+++ b/misc/configvalueloader.py
@@ -17,28 +17,84 @@ from config import config as configm
 
 def _parse_arguments(args):
     parser = argparse.ArgumentParser(description="Configuration Value Loader")
-    parser.add_argument("--key", type=str, required=True,
-        help="The config key for which to load the value, must be prefixed with the config section name")
-    parser.add_argument("--default", type=str, required=False,
-        help="The default value to use if no configured value exists")
+    parser.add_argument("--key", type=str, action='append', required=True,
+        help="The config key for which to load the value, must be prefixed with the config section name. Can be specified multiple times.")
+    parser.add_argument("--separator", type=str, default="|",
+        help="The separator to use between values in output (default: |)")
     parser.add_argument("--repo_root", type=str, required=False,
         help="The root of the repository")
     parser.add_argument("--verbose", required=False, action="store_true",
         help="Verbose output")
     return parser.parse_args(args)
-    
+
+
+def _get_value_from_config(cfg, key):
+    """Gets a value from the config object for the given key.
+
+    Args:
+        cfg: The config object
+        key: The config key (e.g. "artifact.jar_classifier")
+
+    Returns:
+        The configuration value from the config object
+
+    Raises:
+        ValueError: If the key is unknown
+    """
+    # this isn't implemented for all config values yet ...
+    if key == "artifact.jar_classifier":
+        return cfg.jar_artifact_classifier
+    elif key == "general.pom_base_filename":
+        return cfg.pom_base_filename
+    else:
+        raise ValueError("Unknown config key [%s], fix me if needed!" % key)
+
+
+def load_config_values(keys, repo_root, verbose=False):
+    """Loads configuration values for multiple keys.
+
+    Args:
+        keys: List of config keys (e.g. ["artifact.jar_classifier", "general.pom_base_filename"])
+        repo_root: The root of the repository
+        verbose: Enable verbose output
+
+    Returns:
+        Dictionary mapping keys to their values (None if not configured)
+
+    Raises:
+        ValueError: If any key is unknown
+    """
+    cfg = configm.load(repo_root, verbose)
+    result = {}
+    for key in keys:
+        result[key] = _get_value_from_config(cfg, key)
+    return result
+
+
+def format_output(keys, values, separator):
+    """Formats config values as tuple-style output for bash parsing.
+
+    Args:
+        keys: List of config keys in the order they were requested
+        values: Dictionary mapping keys to their values
+        separator: The separator to use between values
+
+    Returns:
+        String with values separated by separator (e.g. "value1|value2")
+    """
+    output_values = []
+    for key in keys:
+        value = values[key]
+        output_values.append(value if value is not None else "None")
+    return separator.join(output_values)
+
 
 if __name__ == "__main__":
     args = _parse_arguments(sys.argv[1:])
     repo_root = common.get_repo_root(args.repo_root)
-    cfg = configm.load(repo_root, args.verbose)
-    # this isn't implemented for all config values yet ...
-    if args.key == "artifact.jar_classifier":
-        value = cfg.jar_artifact_classifier
-    elif args.key == "general.pom_base_filename":
-        value = cfg.pom_base_filename
-    else:
-        sys.exit("Unknown config key [%s], fix me if needed!" % args.key)
-    if value is None:
-        value = args.default
-    print(value)
+    try:
+        values = load_config_values(args.key, repo_root, args.verbose)
+        output = format_output(args.key, values, args.separator)
+        print(output)
+    except ValueError as e:
+        sys.exit(str(e))

--- a/misc/tests/BUILD
+++ b/misc/tests/BUILD
@@ -1,0 +1,22 @@
+load("@aspect_rules_py//py:defs.bzl", "py_test")
+
+
+py_test(
+    name = "extdeps_pomgentest",
+    srcs = ["extdeps_pomgentest.py"],
+    deps = [
+        "//:poppy_lib",
+        "//misc:extdeps_pomgen_lib",
+    ],
+    size = "small",
+)
+
+py_test(
+    name = "configvalueloadertest",
+    srcs = ["configvalueloadertest.py"],
+    deps = [
+        "//:poppy_lib",
+        "//misc:configvalueloader_lib",
+    ],
+    size = "small",
+)

--- a/misc/tests/configvalueloadertest.py
+++ b/misc/tests/configvalueloadertest.py
@@ -1,0 +1,196 @@
+"""
+Copyright (c) 2018, salesforce.com, inc.
+All rights reserved.
+SPDX-License-Identifier: BSD-3-Clause
+For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+"""
+
+import configvalueloader
+import os
+import tempfile
+import unittest
+
+
+class ConfigValueLoaderTest(unittest.TestCase):
+
+    def test_load_jar_classifier__from_config(self):
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, """
+[artifact]
+jar_classifier=jdk8
+""")
+
+        values = configvalueloader.load_config_values(
+            ["artifact.jar_classifier"], repo_root)
+
+        self.assertEqual("jdk8", values["artifact.jar_classifier"])
+
+    def test_load_jar_classifier__not_configured(self):
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, "")
+
+        values = configvalueloader.load_config_values(
+            ["artifact.jar_classifier"], repo_root)
+
+        self.assertIsNone(values["artifact.jar_classifier"])
+
+    def test_load_pom_base_filename__from_config(self):
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, """
+[general]
+pom_base_filename=custom-pom
+""")
+
+        values = configvalueloader.load_config_values(
+            ["general.pom_base_filename"], repo_root)
+
+        self.assertEqual("custom-pom", values["general.pom_base_filename"])
+
+    def test_load_pom_base_filename__default(self):
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, "")
+
+        values = configvalueloader.load_config_values(
+            ["general.pom_base_filename"], repo_root)
+
+        # The config module has its own default of "pom"
+        self.assertEqual("pom", values["general.pom_base_filename"])
+
+    def test_unknown_key(self):
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, "")
+
+        with self.assertRaises(ValueError) as ctx:
+            configvalueloader.load_config_values(
+                ["unknown.key"], repo_root)
+
+        self.assertIn("Unknown config key [unknown.key]", str(ctx.exception))
+
+    def test_load_multiple_values__both_configured(self):
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, """
+[artifact]
+jar_classifier=jdk11
+
+[general]
+pom_base_filename=my-pom
+""")
+
+        values = configvalueloader.load_config_values(
+            ["artifact.jar_classifier", "general.pom_base_filename"], repo_root)
+
+        self.assertEqual(2, len(values))
+        self.assertEqual("jdk11", values["artifact.jar_classifier"])
+        self.assertEqual("my-pom", values["general.pom_base_filename"])
+
+    def test_output_format__tuple_style(self):
+        """Test output is tuple-style with | separator for easy bash parsing."""
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, """
+[artifact]
+jar_classifier=jdk17
+
+[general]
+pom_base_filename=custom-pom
+""")
+
+        keys = ["artifact.jar_classifier", "general.pom_base_filename"]
+        values = configvalueloader.load_config_values(keys, repo_root)
+        output = configvalueloader.format_output(keys, values, "|")
+
+        # Verify output format
+        self.assertEqual("jdk17|custom-pom", output)
+
+        # Verify bash can parse it
+        parts = output.split("|")
+        self.assertEqual(2, len(parts))
+        self.assertEqual("jdk17", parts[0])
+        self.assertEqual("custom-pom", parts[1])
+
+    def test_output_format__with_none_value(self):
+        """Test output when a value is None."""
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, """
+[general]
+pom_base_filename=my-pom
+""")
+
+        keys = ["artifact.jar_classifier", "general.pom_base_filename"]
+        values = configvalueloader.load_config_values(keys, repo_root)
+        output = configvalueloader.format_output(keys, values, "|")
+
+        # Verify output format - None should be represented as string "None"
+        self.assertEqual("None|my-pom", output)
+
+        # Verify bash can parse it
+        parts = output.split("|")
+        self.assertEqual(2, len(parts))
+        self.assertEqual("None", parts[0])
+        self.assertEqual("my-pom", parts[1])
+
+    def test_output_format__custom_separator(self):
+        """Test output with custom separator."""
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, """
+[artifact]
+jar_classifier=jdk17
+
+[general]
+pom_base_filename=custom-pom
+""")
+
+        keys = ["artifact.jar_classifier", "general.pom_base_filename"]
+        values = configvalueloader.load_config_values(keys, repo_root)
+        output = configvalueloader.format_output(keys, values, separator="|||")
+
+        # Verify output format with custom separator
+        self.assertEqual("jdk17|||custom-pom", output)
+
+        # Verify bash can parse it with custom separator
+        parts = output.split("|||")
+        self.assertEqual(2, len(parts))
+        self.assertEqual("jdk17", parts[0])
+        self.assertEqual("custom-pom", parts[1])
+
+    def test_load_multiple_values__one_not_configured(self):
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, """
+[general]
+pom_base_filename=my-pom
+""")
+
+        values = configvalueloader.load_config_values(
+            ["artifact.jar_classifier", "general.pom_base_filename"], repo_root)
+
+        self.assertEqual(2, len(values))
+        self.assertIsNone(values["artifact.jar_classifier"])
+        self.assertEqual("my-pom", values["general.pom_base_filename"])
+
+    def test_load_multiple_values__unknown_key(self):
+        repo_root = tempfile.mkdtemp("root")
+        self._setup_repo(repo_root, "")
+
+        with self.assertRaises(ValueError) as ctx:
+            configvalueloader.load_config_values(
+                ["artifact.jar_classifier", "unknown.key"], repo_root)
+
+        self.assertIn("Unknown config key [unknown.key]", str(ctx.exception))
+
+    def _setup_repo(self, repo_root, poppyrc_content):
+        """Sets up a minimal repository structure for testing."""
+        # Create src/config directory
+        os.makedirs(os.path.join(repo_root, "src/config"))
+
+        # Create pom_template.xml
+        pom_template_path = os.path.join(repo_root, "src/config/pom_template.xml")
+        with open(pom_template_path, "w") as f:
+            f.write("pom template content")
+
+        # Create .poppyrc
+        poppyrc_path = os.path.join(repo_root, ".poppyrc")
+        with open(poppyrc_path, "w") as f:
+            f.write(poppyrc_content)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/misc/tests/extdeps_pomgentest.py
+++ b/misc/tests/extdeps_pomgentest.py
@@ -37,13 +37,13 @@ class ExtDepsPomgenTest(unittest.TestCase):
 
     def _setup_workspace(self):
         self.repo_root_path = tempfile.mkdtemp("monorepo")
-        self._add_WORKSPACE_file()
+        self._add_MODULE_file()
         self._add_maven_install_json_file()
         self._add_pom_template()
         self._add_rc_file()
 
-    def _add_WORKSPACE_file(self):
-        self._write_file("", "", "WORKSPACE", "needs to exist")
+    def _add_MODULE_file(self):
+        self._write_file("", "", "MODULE.bazel", "needs to exist")
 
     def _add_maven_install_json_file(self):
         content = """

--- a/package/maven/maven.sh
+++ b/package/maven/maven.sh
@@ -290,16 +290,11 @@ else
 fi
 
 
-# load the configured classifier to use for jar artifacts, this classifier is
-# used for jars processed below by this script, and it is added to generated
-# pom.xml files referencing those jars
-jar_artifact_classifier=$(bazel run @poppy//misc:configvalueloader -- --key artifact.jar_classifier --default None)
+# load config values in bulk
+config_output=$(bazel run @poppy//misc:configvalueloader -- --key artifact.jar_classifier --key general.pom_base_filename)
 
-# also load the pom base filename - I guess we shouldn't keep adding these load
-# stmts, so if we end up adding a 3rd one, refactor to bulk load in a single
-# call
-pom_base_filename=$(bazel run @poppy//misc:configvalueloader -- --key general.pom_base_filename)
-
+# parse the output (values separated by |)
+IFS='|' read -r jar_artifact_classifier pom_base_filename <<< "$config_output"
 
 for action in $(echo $actions | tr "," "\n")
 do


### PR DESCRIPTION
- Add support for loading multiple config keys in a single invocation
- Add format_output() function with configurable separator (default: |)
- Update maven.sh to load jar_classifier and pom_base_filename in one call
- Add comprehensive test suite for configvalueloader
- Fix extdeps_pomgentest to use MODULE.bazel instead of WORKSPACE
- Organize tests under misc/tests/ using py_library pattern

This reduces overhead from 2 bazel runs to 1 when loading config values, and provides a clean tuple-style output format for easy bash parsing.