### PR TITLE
Add module_labels.txt file for building specific library module targets

### DIFF
--- a/package/maven/maven.sh
+++ b/package/maven/maven.sh
@@ -190,13 +190,13 @@ _for_each_library() {
     local repo_root_path=$2
     local $pom_base_filename=$3
     local jar_artifact_classifier=$4
-    local library_path=$5
+    local root_library_path=$5
 
     if ! [[ "$action" =~ ^(install|build)$ ]]; then
         echo "ERROR: Unknown action $action" && exit 1
     fi
 
-    libraries_file_path="$(_build_libraries_file_path $repo_root_path $library_path)"
+    libraries_file_path="$(_build_libraries_file_path $repo_root_path $root_library_path)"
     echo "[INFO] libraries to process:"
     cat "$libraries_file_path"
     echo ""
@@ -216,6 +216,21 @@ _for_each_library() {
           eval $cmd
         fi
     done <<< "$(cat $libraries_file_path)"
+
+    # Additionally build module labels if the file exists (only for build action)
+    if [ "$action" == "build" ]; then
+        local module_labels_file_path="$repo_root_path/bazel-bin$root_library_path/module_labels.txt"
+        if [ -f "$module_labels_file_path" ]; then
+            echo ""
+            echo "[INFO] Building module labels from: $module_labels_file_path"
+            cat "$module_labels_file_path"
+            echo ""
+            local action_env_args="$(_build_action_env_args)"
+            local cmd="bazel build${action_env_args} --target_pattern_file=\"${module_labels_file_path}\""
+            echo "[INFO] Running $cmd"
+            eval $cmd
+        fi
+    fi
 }
 
 

--- a/src/generate_manifest.py
+++ b/src/generate_manifest.py
@@ -12,6 +12,7 @@ The poppy manifest generation cmdline entry-point.
 import argparse
 import common.argsupport as argsupport
 import common.common as common
+import common.label as label
 import common.logger as logger
 import common.mdfiles as mdfiles
 import config.config as config
@@ -64,6 +65,7 @@ def main(args):
                     # so we do not bother with the other cases for now
                     path = lib_paths[0]
                     _write_all_libraries_hint_files(result, output_dir, path)
+                    _write_module_labels_file(result, output_dir, path)
 
         for ctx in result.artifact_generation_contexts:
             gen_strategy = ctx.artifact_def.generation_strategy
@@ -166,6 +168,24 @@ def _write_all_libraries_hint_files(crawler_result, output_dir, start_lib_path):
         common.write_file(hint_file_path, "\n".join(
             ["# the root lib path, followed by the paths to its upstream dependencies"] + lib_paths))
         logger.info("Wrote libraries hint file to [%s]" % hint_file_path)
+
+
+def _write_module_labels_file(result, output_dir, start_lib_path):
+    artifact_defs = [
+        ctx.artifact_def for ctx in result.artifact_generation_contexts
+        if ctx.artifact_def.bazel_target is not None
+    ]
+    if len(artifact_defs) > 0:
+        labels = sorted([
+            label.Label("//%s:%s" % (ad.bazel_package, ad.bazel_target))
+            for ad in artifact_defs
+        ])
+        labels_file_dir = os.path.join(output_dir, start_lib_path)
+        if not os.path.exists(labels_file_dir):
+            os.makedirs(labels_file_dir)
+        labels_file_path = os.path.join(labels_file_dir, "module_labels.txt")
+        common.write_file(labels_file_path, "\n".join([str(lbl) for lbl in labels]))
+        logger.info("Wrote module labels file to [%s]" % labels_file_path)
 
 
 if __name__ == "__main__":

--- a/tests/examples_goldfiles/examples/java/hello-world/juicer/module_labels.txt
+++ b/tests/examples_goldfiles/examples/java/hello-world/juicer/module_labels.txt
@@ -1,0 +1,2 @@
+//examples/java/hello-world/juicer:juicer_lib
+//examples/java/hello-world/wintervegetables:wintervegetables_lib2

--- a/tests/examples_goldfiles/libraries_release_plan.json
+++ b/tests/examples_goldfiles/libraries_release_plan.json
@@ -68,8 +68,8 @@
     "released_version": null,
     "requires_release": true,
     "release_reason": "artifact has never been released",
-    "proposed_release_version": "20260309.1",
-    "proposed_next_dev_version": "20260309.1-SNAPSHOT"
+    "proposed_release_version": "20260310.1",
+    "proposed_next_dev_version": "20260310.1-SNAPSHOT"
   },
   {
     "library_path": "examples/java/java-import",


### PR DESCRIPTION
- generate_manifest.py: Write module_labels.txt with bazel labels for all artifact modules that have bazel_target set, sorted by canonical label form
- maven.sh: After building library wildcards, additionally build specific module targets using --target_pattern_file if module_labels.txt exists
- Add goldfile for examples/java/hello-world/juicer/module_labels.txt

This allows more precise control over which targets are built during the build action, in addition to the existing library-wide wildcard builds.